### PR TITLE
Change behaviour of "-z" option on "pf data"

### DIFF
--- a/lib/Bio/Path/Find/App/PathFind/Accession.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Accession.pm
@@ -337,14 +337,6 @@ sub _build_filereport_url {
 #- public methods --------------------------------------------------------------
 #-------------------------------------------------------------------------------
 
-=head1 METHODS
-
-=head2 run
-
-Find accessions according to the input parameters.
-
-=cut
-
 sub run {
   my $self = shift;
 

--- a/lib/Bio/Path/Find/App/PathFind/Data.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Data.pm
@@ -565,8 +565,10 @@ sub _make_tar {
 
   #---------------------------------------
 
-  # list the contents of the archive
-  say $_ for @$filenames;
+  # list the contents of the archive. Strip the path from stats.csv, since it's
+  # a file that we generate in a temp directory. That temp dir is deleted as
+  # soon as the file is archived, so it's meaningless to the user
+  say m|/stats.csv$| ? 'stats.csv' : $_ for @$filenames;
 }
 
 #-------------------------------------------------------------------------------
@@ -623,8 +625,10 @@ sub _make_zip {
 
   #---------------------------------------
 
-  # list the contents of the archive
-  say $_ for @$filenames;
+  # list the contents of the archive. Strip the path from stats.csv, since it's
+  # a file that we generate in a temp directory. That temp dir is deleted as
+  # soon as the file is archived, so it's meaningless to the user
+  say m|/stats.csv$| ? 'stats.csv' : $_ for @$filenames;
 }
 
 #-------------------------------------------------------------------------------

--- a/lib/Bio/Path/Find/Lane.pm
+++ b/lib/Bio/Path/Find/Lane.pm
@@ -379,7 +379,7 @@ sub print_paths {
 
 #-------------------------------------------------------------------------------
 
-=head2 make_symlinks(?$dest, ?$filetype)
+=head2 make_symlinks( dest => ?$dest, rename => $?rename, filetype => ?$filetype)
 
 Generate symlinks for files from this lane.
 
@@ -400,6 +400,9 @@ L<Bio::Path::Find::Lane> object.
 If the destination path already exists, either as a link or as a regular file,
 we issue a warning and skip the file. There is no option to overwrite existing
 files/links; move or delete them before trying to create new links.
+
+If C<$rename> is true, filenames will be created with hashes (#) converted into
+underscores (_).
 
 This method throws an exception if it cannot create symlinks, possibly because
 perl itself can't create links on the current platform.
@@ -559,7 +562,7 @@ sub _get_fastqs {
     # for illumina, the database stores the names of the fastq files directly.
     # For pacbio, however, the database stores the names of the bax files. Work
     # out the names of the fastq files from those bax filenames
-    $filename =~ s/\d{1}\.ba[xs]\.h5$/fastq.gz/
+    $filename =~ s/\d\.ba[xs]\.h5$/fastq.gz/
       if $self->row->database->name =~ m/pacbio/;
 
     my $filepath = file( $self->symlink_path, $filename );

--- a/t/12_pf_data_archiving.t
+++ b/t/12_pf_data_archiving.t
@@ -282,8 +282,8 @@ $pf = Bio::Path::Find::App::PathFind::Data->new(%params);
 
 $lanes = $f->find_lanes( ids => [ '10018_1#1' ], type => 'lane', filetype => 'fastq' );
 
-output_like { $pf->_make_archive($lanes) }
-  qr/prokaryotes/,                                    # STDOUT
+output_like { $pf->_make_tar($lanes) }
+  qr/prokaryotes/,                                      # STDOUT
   qr/pathfind_10018_1_1\.tar\.gz.*?Building tar file/s, # STDERR
   'stdout shows correct contents, stderr shows correct filename for tar archive';
 
@@ -305,8 +305,8 @@ $pf = Bio::Path::Find::App::PathFind::Data->new(%params);
 
 $lanes = $f->find_lanes( ids => [ '10018_1#1' ], type => 'lane', filetype => 'fastq' );
 
-output_like { $pf->_make_archive($lanes) }
-  qr/prokaryotes/,                                    # STDOUT
+output_like { $pf->_make_tar($lanes) }
+  qr/prokaryotes/,                                          # STDOUT
   qr/pathfind_10018_1_1\.tar(?!\.gz).*?Building tar file/s, # STDERR
   'stdout shows correct contents, stderr shows correct filename for tar archive';
 
@@ -336,7 +336,7 @@ $params{zip} = 1;
 
 $pf = Bio::Path::Find::App::PathFind::Data->new(%params);
 
-output_like { $pf->_make_archive($lanes) }
+output_like { $pf->_make_zip($lanes) }
   qr/prokaryotes/,                                 # STDOUT
   qr/pathfind_10018_1_1\.zip.*?Writing zip file/s, # STDERR
   'stdout shows correct contents, stderr shows correct filename for zip archive';
@@ -353,13 +353,13 @@ is_deeply [ $zip->memberNames ], [ '10018_1_1/10018_1#1_1.fastq.gz', '10018_1_1/
 
 # check for errors when writing
 
-$params{archive} = file( qw( non-existent-dir test.zip ) );
+$params{zip} = file( qw( non-existent-dir test.zip ) );
 
 $pf = Bio::Path::Find::App::PathFind::Data->new(%params);
 
 $exception_thrown = 0;
 try {
-  stderr_like { $pf->_make_archive($lanes) }
+  stderr_like { $pf->_make_zip($lanes) }
     qr|non-existent-dir.*?Can't open /non-existent-dir/test.zip|,
     'exception when writing zip to expected (broken) location';
 } catch {

--- a/t/15_pf_data.t
+++ b/t/15_pf_data.t
@@ -17,15 +17,19 @@ use MooseX::StrictConstructor;
 extends 'Bio::Path::Find::App::PathFind::Data';
 
 around '_make_symlinks' => sub {
-  return 'called _make_symlinks';
+  print STDERR 'called _make_symlinks';
 };
 
-around '_make_archive' => sub {
-  return 'called _make_archive';
+around '_make_tar' => sub {
+  print STDERR 'called _make_tar';
+};
+
+around '_make_zip' => sub {
+  print STDERR 'called _make_zip';
 };
 
 around '_make_stats' => sub {
-  return 'called _make_stats';
+  print STDERR 'called _make_stats';
 };
 
 #-------------------------------------------------------------------------------
@@ -37,7 +41,7 @@ package main;
 use strict;
 use warnings;
 
-use Test::More tests => 6;
+use Test::More tests => 8;
 use Test::Exception;
 use Test::Output;
 use Path::Class;
@@ -74,7 +78,6 @@ my %params = (
   config_file      => file( qw( t data 15_pf_data test.conf ) ),
   id               => '10018_1',
   type             => 'lane',
-  no_progress_bars => 1,
 );
 
 my $tf;
@@ -90,19 +93,34 @@ stdout_is { $tf->run }
 # make symlinks
 $params{symlink} = 'my_links_dir';
 $tf = Bio::Path::Find::App::TestFind->new(%params);
-is $tf->run, 'called _make_symlinks', 'correctly called _make_symlinks';
+stderr_is { $tf->run } 'called _make_symlinks', 'correctly called _make_symlinks';
 
-# make archive
+# make tar
 delete $params{symlink};
 $params{archive} = 'my_archive';
 $tf = Bio::Path::Find::App::TestFind->new(%params);
-is $tf->run, 'called _make_archive', 'correctly called _make_archive';
+stderr_is { $tf->run } 'called _make_tar', 'correctly called _make_tar';
+
+# make tar
+delete $params{archive};
+$params{zip} = 'my_zip';
+$tf = Bio::Path::Find::App::TestFind->new(%params);
+stderr_is { $tf->run } 'called _make_zip', 'correctly called _make_zip';
 
 # make stats
-delete $params{archive};
+delete $params{zip};
 $params{stats} = 'my_stats';
 $tf = Bio::Path::Find::App::TestFind->new(%params);
-is $tf->run, 'called _make_stats', 'correctly called _make_stats';
+stderr_is { $tf->run } 'called _make_stats', 'correctly called _make_stats';
+
+# multiple flags
+$params{archive} = 'my_tar';
+$params{stats}   = 'my_stats';
+$params{zip}     = 'my_zip';
+$tf = Bio::Path::Find::App::TestFind->new(%params);
+stderr_like { $tf->run }
+  qr/called _make_tar.*?_make_zip.*?_make_stats/,
+  'correctly called multiple _make_* methods';
 
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR changes the behaviour of the "-z" option on "pf data", hopefully making it more rational. 

Previously the zip option had to be used along with "--archive", telling the script to write an archive but to make it zip not tar. This PR makes the "-a" and "-z" options independent, so to write a tar archive you'd add "-a" and to write a zip you'd add "-z".

It's possible (and allowed) to write both a tarball and zip file in the same run, though it's a slightly strange thing to do.