### PR TITLE
Fix lane role

### DIFF
--- a/lib/Bio/Path/Find/App/PathFind/Data.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Data.pm
@@ -397,6 +397,19 @@ sub _stats_file_builder {
 }
 
 #-------------------------------------------------------------------------------
+#- private attributes ----------------------------------------------------------
+#-------------------------------------------------------------------------------
+
+# this is a builder for the "_lane_role" attribute that's defined on the parent
+# class, B::P::F::A::PathFind. The return value specifies the name of a Role
+# that should be applied to the B::P::F::Lane objects that are returned by the
+# Finder.
+
+sub _build_lane_role {
+  return 'Bio::Path::Find::Lane::Role::PathFind';
+}
+
+#-------------------------------------------------------------------------------
 #- public methods --------------------------------------------------------------
 #-------------------------------------------------------------------------------
 

--- a/lib/Bio/Path/Find/Lane/Role/PathFind.pm
+++ b/lib/Bio/Path/Find/Lane/Role/PathFind.pm
@@ -1,7 +1,7 @@
 
 package Bio::Path::Find::Lane::Role::PathFind;
 
-# ABSTRACT: a role that collects together statistics for a lane
+# ABSTRACT: a role that adds pathfind-specific functionality to the B::P::F::Lane class
 
 use Moose::Role;
 use Path::Class;

--- a/t/07_finder.t
+++ b/t/07_finder.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 20;
+use Test::More tests => 16;
 use Test::Exception;
 use Test::Output;
 use Path::Class;
@@ -78,12 +78,12 @@ ok $lanes->[0]->does('Bio::Path::Find::Lane::Role::PathFind'),
 # check the behaviour of the lane_roles section of the config
 
 # first, let's see if we can look up the Role to apply using the name of the
-# calling script. We set the name of the script to one that we know exists
-# in the default script name-to-Role name mapping that's hard coded into
+# calling script. We set the name of the command class to one that we know
+# exists in the default script name-to-Role name mapping that's hard coded into
 # the class
 $f = Bio::Path::Find::Finder->new(
-  config       => $config,
-  _script_name => 'pathfind',
+  config    => $config,
+  lane_role => 'Bio::Path::Find::Lane::Role::PathFind',
 );
 
 lives_ok { $lanes = $f->find_lanes( ids => [ '10263_4' ], type => 'lane' ) }
@@ -95,8 +95,7 @@ ok $lanes->[0]->does('Bio::Path::Find::Lane::Role::PathFind'),
 # and make sure that we don't have any problems when we don't have
 # a Role to apply
 $f = Bio::Path::Find::Finder->new(
-  config       => $config,
-  _script_name => 'my_script',
+  config    => $config,
 );
 
 lives_ok { $lanes = $f->find_lanes( ids => [ '10263_4' ], type => 'lane' ) }
@@ -104,25 +103,6 @@ lives_ok { $lanes = $f->find_lanes( ids => [ '10263_4' ], type => 'lane' ) }
 
 ok ! $lanes->[0]->does('Bio::Path::Find::Lane::Role::PathFind'),
   'no roles applied to lanes';
-
-#---------------------------------------
-
-# next, if we specify the lane roles mapping in the config, we should get the
-# right value for lane_role and that Role should be applied to found lanes
-$config->{lane_roles} = {
-  '07_finder.t' => 'Bio::Path::Find::Lane::Role::PathFind',
-};
-
-lives_ok { $f = Bio::Path::Find::Finder->new( config => $config ) }
-  'got a finder with config having lane_roles section';
-
-is $f->lane_role, 'Bio::Path::Find::Lane::Role::PathFind', 'got correct lane role';
-
-lives_ok { $lanes = $f->find_lanes( ids => [ '10263_4' ], type => 'lane' ) }
-  'no exception finding lanes when script named in lane_roles';
-
-ok $lanes->[0]->does('Bio::Path::Find::Lane::Role::PathFind'),
-  'correct role applied to lane';
 
 #---------------------------------------
 

--- a/t/data/07_finder/test.conf
+++ b/t/data/07_finder/test.conf
@@ -15,9 +15,5 @@ hierarchy_template genus:species-subspecies:TRACKING:projectssid:sample:technolo
   pathogen_prok_track     prokaryotes
 </db_subdirs>
 
-<lane_roles>
-  pathfind     Bio::Path::Find::Lane::Role::PathFind
-</lane_roles>
-
 no_progress_bars 1
 

--- a/t/data/07_finder/test_with_lane_role.conf
+++ b/t/data/07_finder/test_with_lane_role.conf
@@ -15,10 +15,5 @@ hierarchy_template genus:species-subspecies:TRACKING:projectssid:sample:technolo
   pathogen_prok_track     prokaryotes
 </db_subdirs>
 
-# set the name of the script correctly
-<lane_roles>
-  07_finder.t     Bio::Path::Find::Lane::Role::PathFind
-</lane_roles>
-
 no_progress_bars 1
 

--- a/t/data/11_pf_boilerplate/test.conf
+++ b/t/data/11_pf_boilerplate/test.conf
@@ -12,7 +12,3 @@ hierarchy_template genus:species-subspecies:TRACKING:projectssid:sample:technolo
   pathogen_prok_track     prokaryotes
 </db_subdirs>
 
-<lane_roles>
-  11_approle.t     Bio::Path::Find::Lane::Role::PathFind
-</lane_roles>
-

--- a/t/data/12_pf_data_archiving/test.conf
+++ b/t/data/12_pf_data_archiving/test.conf
@@ -15,9 +15,5 @@ hierarchy_template genus:species-subspecies:TRACKING:projectssid:sample:technolo
   pathogen_prok_track     prokaryotes
 </db_subdirs>
 
-<lane_roles>
-  12_pathfind_archiving.t     Bio::Path::Find::Lane::Role::PathFind
-</lane_roles>
-
 no_progress_bars 1
 

--- a/t/data/13_pf_data_symlinking/test.conf
+++ b/t/data/13_pf_data_symlinking/test.conf
@@ -15,9 +15,5 @@ hierarchy_template genus:species-subspecies:TRACKING:projectssid:sample:technolo
   pathogen_prok_track     prokaryotes
 </db_subdirs>
 
-<lane_roles>
-  13_pathfind_symlinking.t     Bio::Path::Find::Lane::Role::PathFind
-</lane_roles>
-
 no_progress_bars 1
 

--- a/t/data/14_pf_data_stats/test.conf
+++ b/t/data/14_pf_data_stats/test.conf
@@ -15,9 +15,5 @@ hierarchy_template genus:species-subspecies:TRACKING:projectssid:sample:technolo
   pathogen_prok_track     prokaryotes
 </db_subdirs>
 
-<lane_roles>
-  14_pathfind_stats.t     Bio::Path::Find::Lane::Role::PathFind
-</lane_roles>
-
 no_progress_bars 1
 

--- a/t/data/15_pf_data/test.conf
+++ b/t/data/15_pf_data/test.conf
@@ -15,9 +15,5 @@ hierarchy_template genus:species-subspecies:TRACKING:projectssid:sample:technolo
   pathogen_prok_track     prokaryotes
 </db_subdirs>
 
-<lane_roles>
-  15_pathfind.t     Bio::Path::Find::Lane::Role::PathFind
-</lane_roles>
-
 no_progress_bars 1
 

--- a/t/data/16_pf_data_script/no_log.conf
+++ b/t/data/16_pf_data_script/no_log.conf
@@ -16,7 +16,3 @@ db_root t/data/linked
   pathogen_prok_track     prokaryotes
 </db_subdirs>
 
-<lane_roles>
-   pathfind  Bio::Path::Find::Lane::Role::PathFind
-</lane_roles>
-

--- a/t/data/16_pf_data_script/prod.conf
+++ b/t/data/16_pf_data_script/prod.conf
@@ -16,7 +16,3 @@ db_root t/data/linked
   pathogen_prok_track     prokaryotes
 </db_subdirs>
 
-<lane_roles>
-   pathfind  Bio::Path::Find::Lane::Role::PathFind
-</lane_roles>
-


### PR DESCRIPTION
This PR gets rid of the mappings that link script name to the Roles that get applied to the found Lanes.