### PR TITLE
Add mechanism to force overwriting of existing files

### DIFF
--- a/lib/Bio/Path/Find/Lane.pm
+++ b/lib/Bio/Path/Find/Lane.pm
@@ -377,7 +377,7 @@ sub print_paths {
 
 #-------------------------------------------------------------------------------
 
-=head2 make_symlinks( dest => ?$dest, rename => $?rename, filetype => ?$filetype)
+=head2 make_symlinks( dest => ?$dest, rename => $?rename, filetype => ?$filetype )
 
 Generate symlinks for files from this lane.
 
@@ -413,9 +413,9 @@ sub make_symlinks {
   state $check = compile(
     Object,
     slurpy Dict [
-      dest     => Optional [PathClassDir],
-      rename   => Optional [Bool],
-      filetype => Optional [FileType]
+      dest     => Optional[PathClassDir],
+      rename   => Optional[Bool],
+      filetype => Optional[FileType],
     ],
   );
   my ( $self, $params ) = $check->(@_);
@@ -482,12 +482,12 @@ sub _make_file_symlinks {
 
     # sanity check: don't overwrite the destination file
     if ( -f $dst_file ) {
-      carp "WARNING: destination file ($dst_file) already exists; skipping";
+      carp qq(WARNING: destination file ($dst_file) already exists; skipping.);
       next FILE;
     }
 
     if ( -l $dst_file ) {
-      carp "WARNING: destination file ($dst_file) is already a symlink; skipping";
+      carp qq(WARNING: destination file ($dst_file) is already a symlink; skipping.);
       next FILE;
     }
 
@@ -532,12 +532,12 @@ sub _make_dir_symlink {
   # TODO should we add a call to "_edit_filenames" here too ?
 
   if ( -e $dst_dir ) {
-    carp "WARNING: destination dir ($dst_dir) already exists; skipping";
+    carp qq(WARNING: destination dir ($dst_dir) already exists; skipping.);
     return 0;
   }
 
   if ( -l $dst_dir ) {
-    carp "WARNING: destination dir ($dst_dir) is already a symlink; skipping";
+    carp qq(WARNING: destination dir ($dst_dir) is already a symlink; skipping.);
     return 0;
   }
 

--- a/lib/Bio/Path/Find/Role/Archivist.pm
+++ b/lib/Bio/Path/Find/Role/Archivist.pm
@@ -181,7 +181,7 @@ sub _make_tar {
              ? $tar_contents
              : $self->_compress_data($tar_contents);
 
-  # and write it out, gzip compressed
+  # and write it out
   $self->_write_data( $output, $archive_filename );
 
   #---------------------------------------
@@ -222,6 +222,12 @@ sub _make_zip {
   print STDERR 'Writing zip file... ';
 
   # write it to file
+  if ( -e $archive_filename and not $self->force ) {
+    Bio::Path::Find::Exception->throw(
+      msg => qq(ERROR: output file "$archive_filename" already exists; not overwriting. Use "-F" to force overwriting)
+    );
+  }
+
   try {
     unless ( $zip->writeToFileNamed($archive_filename->stringify) == AZ_OK ) {
       print STDERR "failed\n";
@@ -386,6 +392,12 @@ sub _compress_data {
 
 sub _write_data {
   my ( $self, $data, $filename ) = @_;
+
+  if ( -e $filename and not $self->force ) {
+    Bio::Path::Find::Exception->throw(
+      msg => qq(ERROR: output file "$filename" already exists; not overwriting. Use "-F" to force overwriting)
+    );
+  }
 
   my $max        = length $data;
   my $num_chunks = 100;

--- a/t/11_pf_boilerplate.t
+++ b/t/11_pf_boilerplate.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 15;
+use Test::More tests => 16;
 use Test::Exception;
 use Test::Output;
 use Path::Class;
@@ -83,6 +83,12 @@ is_deeply $stats, \@expected_stats, 'written contents look right';
 throws_ok { $tf->_write_csv(\@expected_stats, $stats_file) }
   qr/not overwriting/,
   'exception when file already exists';
+
+$params{force} = 1;
+my $tf_force = Bio::Path::Find::App::PathFind->new(%params);
+
+lives_ok { $tf_force->_write_csv(\@expected_stats, $stats_file) }
+  'no exception when file already exists but "force" is true';
 
 $stats_file->remove;
 

--- a/t/14_pf_data_stats.t
+++ b/t/14_pf_data_stats.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 10;
+use Test::More tests => 12;
 use Test::Exception;
 use Test::Output;
 use Test::Warn;
@@ -100,6 +100,17 @@ ok -e $stats_file, 'stats named as expected';
 
 $stats = csv( in => $stats_file->stringify );
 is_deeply $stats, \@expected_stats, 'contents of named file look right';
+
+# should get an error when writing to the same file a second time
+throws_ok { $pf->_make_stats($lanes) }
+  qr/already exists/,
+  'exception when calling _make_stats with existing file';
+
+$params{force} = 1;
+$pf = Bio::Path::Find::App::PathFind::Data->new(%params);
+
+lives_ok { $pf->_make_stats($lanes) }
+  'no exception when calling _make_stats with existing file but "force" is set to true';
 
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
Add a "--force" / "-F" option to the main PathFind app, which is a flag
to show that existing files should be overwritten. This doesn't affect
the creation of symlinks, where it's still an error to try to overwrite.

Creating symlinks is more difficult to simply force, because it the perl
built-in "symlink" refuses to create links at existing destinations, so
forcing would require us to first remove existing destination files or
directories, and I'm not sure should be doing that.