### PR TITLE
Fix symlink output

### DIFF
--- a/lib/Bio/Path/Find/Lane.pm
+++ b/lib/Bio/Path/Find/Lane.pm
@@ -544,7 +544,6 @@ sub make_symlinks {
 sub _make_file_symlinks {
   my ( $self, $dest, $rename ) = @_;
 
-  my $num_successful_links = 0;
   my @links = ();
   FILE: foreach my $src_file ( $self->all_files ) {
 
@@ -588,7 +587,6 @@ sub _make_file_symlinks {
       # platform
       Bio::Path::Find::Exception->throw( msg => "ERROR: cannot create symlinks: $_" );
     };
-    $num_successful_links += $success;
 
     if ( $success ) {
       push @links, $src_file;
@@ -598,7 +596,7 @@ sub _make_file_symlinks {
     }
   }
 
-  $self->log->debug("created $num_successful_links links");
+  $self->log->debug('created ' . scalar @links . ' links');
 
   return \@links;
 }

--- a/lib/Bio/Path/Find/Lane.pm
+++ b/lib/Bio/Path/Find/Lane.pm
@@ -485,7 +485,8 @@ underscores (_).
 This method throws an exception if it cannot create symlinks, possibly because
 perl itself can't create links on the current platform.
 
-Returns the number of links created.
+Returns a reference to an array containing a list of linked entities (either
+file or directory paths, depending on what was found).
 
 =cut
 
@@ -516,19 +517,19 @@ sub make_symlinks {
     $self->find_files( $params->{filetype} );
   }
 
-  my $rv = 0;
+  my $links;
   if ( $self->_finding_run ) {
     if ( $self->has_no_files ) {
       carp 'WARNING: no files found for linking';
       return 0;
     }
-    $rv = $self->_make_file_symlinks( $params->{dest}, $params->{rename} );
+    $links = $self->_make_file_symlinks( $params->{dest}, $params->{rename} );
   }
   else {
-    $rv = $self->_make_dir_symlink( $params->{dest}, $params->{rename} );
+    $links = $self->_make_dir_symlink( $params->{dest}, $params->{rename} );
   }
 
-  return $rv;
+  return $links;
 }
 
 #-------------------------------------------------------------------------------
@@ -536,11 +537,15 @@ sub make_symlinks {
 #-------------------------------------------------------------------------------
 
 # make a link to the found files for this lane
+#
+# returns a reference to an array containing the list of files that we linked,
+# or an empty array if we couldn't create any links
 
 sub _make_file_symlinks {
   my ( $self, $dest, $rename ) = @_;
 
   my $num_successful_links = 0;
+  my @links = ();
   FILE: foreach my $src_file ( $self->all_files ) {
 
     my $filename = file($src_file)->basename;
@@ -569,6 +574,11 @@ sub _make_file_symlinks {
       next FILE;
     }
 
+    # the "symlink" call will die if it simply can't make symlinks on this
+    # platform, but it returns false if it can't create a link for another
+    # reason, such as when the destination file already exists. We need to
+    # check for those two outcomes (exception versus return value) separately.
+
     my $success = 0;
     try {
       $success = symlink( $src_file, $dst_file );
@@ -581,7 +591,7 @@ sub _make_file_symlinks {
     $num_successful_links += $success;
 
     if ( $success ) {
-      say $src_file;
+      push @links, $src_file;
     }
     else {
       carp qq(WARNING: failed to create symlink for "$src_file");
@@ -590,13 +600,16 @@ sub _make_file_symlinks {
 
   $self->log->debug("created $num_successful_links links");
 
-  return $num_successful_links;
+  return \@links;
 }
 
 #-------------------------------------------------------------------------------
 
 # make a link to the directory containing the files for this lane. Actually, we
 # make a link to the link to that directory, but... semantics
+#
+# returns a reference to an array containing the name of the directory that we
+# linked, or an empty array if we couldn't create the link
 
 sub _make_dir_symlink {
   my ( $self, $dest, $rename ) = @_;
@@ -637,7 +650,10 @@ sub _make_dir_symlink {
 
   carp qq(WARNING: failed to create symlink for "$dest") unless $success;
 
-  return $success;
+  # if we succeeded in creating a symlink to the destination directory, return
+  # a ref to an array with that single path. Otherwise, return an empty
+  # directory and let the caller handle it
+  return $success ? [ $dst_dir ] : [];
 }
 
 #-------------------------------------------------------------------------------

--- a/lib/Bio/Path/Find/Role/Linker.pm
+++ b/lib/Bio/Path/Find/Role/Linker.pm
@@ -3,6 +3,8 @@ package Bio::Path::Find::Role::Linker;
 
 # ABSTRACT: role providing methods for creating symlinks for found files
 
+use v5.10; # for "say"
+
 use MooseX::App::Role;
 
 =head1 CONTACT
@@ -113,10 +115,24 @@ sub _make_symlinks {
   my $pb = $self->_create_pb('linking', scalar @$lanes);
 
   my $i = 0;
+  my @links = ();
   foreach my $lane ( @$lanes ) {
-    $lane->make_symlinks( dest => $dest, rename => $self->rename );
+    # the call to "make_symlinks" returns a reference to an array containing a
+    # list of the entities (files or directories) for which the Lane has
+    # successfully created links. We need to collect those and list them later,
+    # when we're not in the middle of showing a progress bar
+    push @links, $lane->make_symlinks( dest => $dest, rename => $self->rename );
     $pb++;
   }
+
+  # walk the list of array refs...
+  foreach my $lane_links ( @links ) {
+    # and walk the array containing the list of linked entities for each Lane
+    foreach my $link ( @$lane_links ) {
+      say $link;
+    }
+  }
+
 }
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
The output of the annotation command's "make symlinks" option previously interleaved the list of linked files with an ongoing progress bar. This PF fixes that by saving the list of linked files and printing them all at once, after the progress bar has been removed.