### PR TITLE
Fix naming of files in archives

### DIFF
--- a/lib/Bio/Path/Find/App/PathFind.pm
+++ b/lib/Bio/Path/Find/App/PathFind.pm
@@ -539,37 +539,6 @@ sub _load_ids_from_file {
 
 #-------------------------------------------------------------------------------
 
-# generates a new filename by converting hashes to underscores in the supplied
-# filename. Also converts the filename to unix format, for use with tar and
-# zip
-
-sub _rename_file {
-  my ( $self, $old_filename ) = @_;
-
-  my $new_basename = $old_filename->basename;
-
-  # honour the "--rename" option
-  $new_basename =~ s/\#/_/g if $self->rename;
-
-  # add on the folder to get the relative path for the file in the
-  # archive
-  my $folder_name = $self->id;
-  $folder_name =~ s/\#/_/g if $self->rename;
-
-  my $new_filename = file( $folder_name, $new_basename );
-
-  # filenames in an archive are specified as Unix paths (see
-  # https://metacpan.org/pod/Archive::Tar#tar-rename-file-new_name)
-  $old_filename = file( $old_filename )->as_foreign('Unix');
-  $new_filename = file( $new_filename )->as_foreign('Unix');
-
-  $self->log->debug( "renaming |$old_filename| to |$new_filename|" );
-
-  return $new_filename;
-}
-
-#-------------------------------------------------------------------------------
-
 # modifier for methods that write to file. Takes care of validating arguments
 # and opening a filehandle for writing
 

--- a/lib/Bio/Path/Find/App/PathFind/QC.pm
+++ b/lib/Bio/Path/Find/App/PathFind/QC.pm
@@ -350,7 +350,15 @@ sub run {
 sub _collect_filenames {
   my ( $self, $lanes ) = @_;
 
-  my @kraken_report_files = map { $_->all_files } @$lanes;
+  my @kraken_report_files;
+
+  foreach my $lane ( @$lanes ) {
+    foreach my $file ( $lane->all_files ) {
+      push @kraken_report_files, { $file => $file };
+    }
+  }
+
+  # my @kraken_report_files = map { $_->all_files } @$lanes;
 
   return \@kraken_report_files;
 }

--- a/lib/Bio/Path/Find/App/PathFind/Ref.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Ref.pm
@@ -575,9 +575,12 @@ sub _get_dir_name {
 
 # overwrite two methods that are used by "_make_tar" and "_make_zip" from the
 # Archivist Role for gathering filenames and renaming them in the archives.
-
+#
 # we don't actually need to do anything in _collect_filenames. We've already
 # found the paths that we're interested in. Just replace the original.
+#
+# (this is a bit naughty. It changes the behaviour and the return value(s) of
+# the method.)
 
 sub _collect_filenames {
   my ( $self, $paths ) = @_;
@@ -587,8 +590,8 @@ sub _collect_filenames {
 
 #---------------------------------------
 
-# used by "_make_tar" and "_make_zip" from the Archivist Role for renaming
-# files in the archives.
+# this method is provided by the Archivist Role, and is used by the "_make_tar"
+# and "_make_zip" methods from the Role for renaming files in the archives
 
 sub _rename_file {
   my ( $self, $old_filename ) = @_;

--- a/lib/Bio/Path/Find/App/Role/Archivist.pm
+++ b/lib/Bio/Path/Find/App/Role/Archivist.pm
@@ -301,8 +301,6 @@ sub _collect_filenames {
 sub _rename_file {
   my ( $self, $old_filename ) = @_;
 
-  return unless ( $old_filename and -f $old_filename );
-
   my $new_basename = $old_filename->basename;
 
   # honour the "--rename" option

--- a/lib/Bio/Path/Find/Lane.pm
+++ b/lib/Bio/Path/Find/Lane.pm
@@ -557,8 +557,8 @@ sub _make_file_symlinks {
     # provide a hook for Lane Roles to edit filenames, if necessary
     #
     # if the Lane has a "_edit_link_filenames" method, which should come from a
-    # Role applied to the Lane, call the method to edit the "from" and "to"
-    # filenames for the link
+    # Lane sub-class, call the method to edit the "from" and "to" filenames for
+    # the link
     ( $src_file, $dst_file ) = $self->_edit_filenames( $src_file, $dst_file )
       if $self->can('_edit_filenames');
 

--- a/t/12_pf_data_archiving.t
+++ b/t/12_pf_data_archiving.t
@@ -170,7 +170,7 @@ unshift @expected_file_hashes, { 'bad_filename' => file('bad_filename') };
 warnings_like { $pf->_create_tar_archive(\@expected_file_hashes, $stats_file) }
   [
     { carped => qr/No such file:/ },
-    # { carped => qr/No such file in archive/ },
+    { carped => qr/No such file in archive/ },
     { carped => qr/couldn't rename/ },
   ],
   'warnings when adding bogus file to archive';

--- a/t/12_pf_data_archiving.t
+++ b/t/12_pf_data_archiving.t
@@ -73,6 +73,9 @@ my @expected_filenames = file( qw( t data 12_pf_data_archiving expected_filename
 my @expected_stats     = file( qw( t data 12_pf_data_archiving expected_stats.txt ) )->slurp(chomp => 1, split => qr|\t| );
 
 # turn all of the expected filenames into Path::Class::File objects...
+my @expected_file_hashes;
+push @expected_file_hashes, { file($_) => file($_) } for @expected_filenames;
+
 for ( my $i = 0; $i < scalar @expected_filenames; $i++ ) {
   $expected_filenames[$i] = file( $expected_filenames[$i] );
 }
@@ -99,7 +102,12 @@ warning_like { ( $got_filenames, $got_stats ) = $pf->_collect_filenames($lanes) 
   qr/Permission denied/,
   'got "permission denied" warning with unreadable job status file';
 
-is_deeply $got_filenames, \@expected_filenames,
+# convert the arrayref of hashrefs from _collect_filenames into just the
+# raw file paths
+my @got_files;
+push @got_files, keys %$_ for @$got_filenames;
+
+is_deeply \@got_files, \@expected_filenames,
   'got expected list of filenames from _collect_filenames';
 
 is_deeply $got_stats, \@expected_stats,
@@ -131,25 +139,24 @@ lives_ok { $pf = Bio::Path::Find::App::PathFind::Data->new(%params) }
   'got a new pathfind data command object';
 
 # add the stats file to the archive
-push @expected_filenames, file( qw( t data 12_pf_data_archiving stats.csv ) );
+my $stats_file = file( qw( t data 12_pf_data_archiving stats.csv ) );
 
 my $archive;
-lives_ok { $archive = $pf->_create_tar_archive(\@expected_filenames) }
+lives_ok { $archive = $pf->_create_tar_archive(\@expected_file_hashes, $stats_file) }
   'no problems adding files to archive';
 
 my @archived_files = $archive->list_files;
 
 is scalar @archived_files, 51, 'got expected number of files in archive';
-is $archived_files[0], '10018_1/10018_1#1_1.fastq.gz', 'first file looks right';
-# is $archived_files[-1], '10018_1/10018_1#51_1.fastq.gz', 'last file looks right';
-is $archived_files[-1], '10018_1/stats.csv', 'last file is stats.csv';
+is $archived_files[0],  '10018_1/10018_1#1_1.fastq.gz', 'first file is fastq';
+is $archived_files[-1], '10018_1/stats.csv',            'last file is stats.csv';
 
 my $gzipped_data = $archive->get_content('10018_1/10018_1#1_1.fastq.gz');
 my $raw_data = Compress::Zlib::memGunzip($gzipped_data);
 is $raw_data, "some data\n", 'first file has expected content';
 
-my $expected_stats_file = file( qw( t data 12_pf_data_archiving stats.csv ) )->slurp;
 my $got_stats_file = $archive->get_content('10018_1/stats.csv');
+my $expected_stats_file = file( qw( t data 12_pf_data_archiving stats.csv ) )->slurp;
 
 is $got_stats_file, $expected_stats_file, 'extracted stats file looks right';
 
@@ -157,17 +164,19 @@ is $got_stats_file, $expected_stats_file, 'extracted stats file looks right';
 
 # check the exception when we try to add a non-existent file to the archive
 
-push @expected_filenames, file('bad_filename');
+# put a bad file on the front of the list of hashes
+unshift @expected_file_hashes, { 'bad_filename' => file('bad_filename') };
 
-warnings_like { $pf->_create_tar_archive(\@expected_filenames) }
+warnings_like { $pf->_create_tar_archive(\@expected_file_hashes, $stats_file) }
   [
     { carped => qr/No such file:/ },
-    { carped => qr/No such file in archive/ },
+    # { carped => qr/No such file in archive/ },
     { carped => qr/couldn't rename/ },
   ],
   'warnings when adding bogus file to archive';
 
-pop @expected_filenames;
+# reset file hashes; remove bad file
+shift @expected_file_hashes;
 
 #---------------------------------------
 
@@ -183,7 +192,7 @@ pop @expected_filenames;
 lives_ok { $pf = Bio::Path::Find::App::PathFind::Data->new(%params) }
   'no exception with "rename" option';
 
-lives_ok { $archive = $pf->_create_tar_archive(\@expected_filenames) }
+lives_ok { $archive = $pf->_create_tar_archive(\@expected_file_hashes, $stats_file) }
   'no problems adding files to archive';
 
 @archived_files = $archive->list_files;
@@ -261,17 +270,8 @@ is $uncompressed_slurped_data, $data, 'file written to disk matches original';
 
 $pf = Bio::Path::Find::App::PathFind::Data->new(%params);
 
-# set up the list of expected filenames again from scratch
-@expected_filenames = file( qw( t data 12_pf_data_archiving expected_filenames.txt ) )->slurp(chomp => 1);
-push @expected_filenames, file( qw( t data 12_pf_data_archiving stats.csv ) );
-
-# turn all of the expected filenames into Path::Class::File objects...
-for ( my $i = 0; $i < scalar @expected_filenames; $i++ ) {
-  $expected_filenames[$i] = file( $expected_filenames[$i] );
-}
-
 my $zip;
-lives_ok { $zip = $pf->_create_zip_archive(\@expected_filenames) }
+lives_ok { $zip = $pf->_create_zip_archive(\@expected_file_hashes, $stats_file) }
   'no exception when building zip archive';
 
 isa_ok $zip, 'Archive::Zip::Archive', 'zip archive';
@@ -280,7 +280,7 @@ my @zip_members = $zip->memberNames;
 is scalar @zip_members, 51, 'zip has correct number of members';
 
 is $zip_members[0],  '10018_1/10018_1#1_1.fastq.gz', 'first member has correct name';
-is $zip_members[-1], '10018_1/stats.csv', 'last member has correct name';
+is $zip_members[-1], '10018_1/stats.csv',             'last member has correct name';
 
 #-------------------------------------------------------------------------------
 
@@ -313,7 +313,7 @@ ok -f $archive, 'found tar archive';
 my $tar = Archive::Tar->new;
 
 lives_ok { $tar->read($archive->stringify) } 'no problem reading tar archive';
-is_deeply [ $tar->list_files ], [ '10018_1#1/10018_1#1_1.fastq.gz', '10018_1#1/stats.csv' ],
+is_deeply [ $tar->list_files ], [ '10018_1_1/10018_1#1_1.fastq.gz', '10018_1_1/stats.csv' ],
   'got expected files in tar archive';
 
 # check we can write uncompressed tar files
@@ -392,7 +392,7 @@ ok ! $exception_thrown, 'no error when writing to existing file but "force" is t
 $zip = Archive::Zip->new;
 
 is $zip->read("$archive"), AZ_OK, 'no problem reading zip archive';
-is_deeply [ $zip->memberNames ], [ '10018_1#1/10018_1#1_1.fastq.gz', '10018_1#1/stats.csv' ],
+is_deeply [ $zip->memberNames ], [ '10018_1_1/10018_1#1_1.fastq.gz', '10018_1_1/stats.csv' ],
   'got expected files in zip archive';
 
 # check for errors when writing

--- a/t/28_pf_qc.t
+++ b/t/28_pf_qc.t
@@ -73,7 +73,7 @@ $qc->clear_config;
 $qc = Bio::Path::Find::App::PathFind::QC->new(%params);
 
 output_like { $qc->run }
-  qr/kraken.report/,                # stdout
+  qr/kraken\.report/,              # stdout
   qr/Archiving data to '$output'/, # stderr
   'succeeded in writing tar file';
 


### PR DESCRIPTION
This PR fixes the issue raised in RT#521518, related to the naming of files in archives created by `pf assembly`.