### PR TITLE
Fix bug with the "--file_id_type" option for some commands

### DIFF
--- a/lib/Bio/Path/Find/App/PathFind/Accession.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Accession.pm
@@ -354,7 +354,7 @@ sub run {
   # find lanes
   my $lanes = $self->_finder->find_lanes(
     ids  => $self->_ids,
-    type => $self->type,
+    type => $self->_type,
   );
 
   $self->log->debug('found ' . scalar @$lanes . ' lanes');

--- a/lib/Bio/Path/Find/App/PathFind/Info.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Info.pm
@@ -284,7 +284,7 @@ sub run {
   # find lanes
   my $lanes = $self->_finder->find_lanes(
     ids  => $self->_ids,
-    type => $self->type,
+    type => $self->_type,
   );
 
   my $pb = $self->_create_pb('collecting info', scalar @$lanes);

--- a/lib/Bio/Path/Find/App/PathFind/Map.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Map.pm
@@ -305,7 +305,7 @@ sub run {
   # build the parameters for the finder
   my %finder_params = (
     ids      => $self->_ids,
-    type     => $self->type,
+    type     => $self->_type,
     filetype => 'bam',  # triggers a call to B::P::F::Lane::Class::Map::_get_bam
   );                    # for file finding
 

--- a/lib/Bio/Path/Find/App/PathFind/QC.pm
+++ b/lib/Bio/Path/Find/App/PathFind/QC.pm
@@ -303,7 +303,7 @@ sub run {
 
   my %finder_params = (
     ids      => $self->_ids,
-    type     => $self->type,
+    type     => $self->_type,
     filetype => 'kraken',
   );
 

--- a/lib/Bio/Path/Find/App/PathFind/Status.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Status.pm
@@ -231,7 +231,7 @@ sub run {
   # find lanes
   my $lanes = $self->_finder->find_lanes(
     ids  => $self->_ids,
-    type => $self->type,
+    type => $self->_type,
   );
 
   my $pb = $self->_create_pb('collecting info', scalar @$lanes);


### PR DESCRIPTION
There was a bug in some commands with the `--file_id_type` option, which meant that they were using the value of `--type` to give the types of files to find, even when that type was `file`. They should have been using a private attribute, `_type`, which is set by the builder on the app class and gives the actual type of the IDs that are to be used for searching.

This PR adds an underscore to each of the affected command clases...