### PR TITLE
Convert filenames to Path::Class::File objects

### DIFF
--- a/lib/Bio/Path/Find/App/Role/Archivist.pm
+++ b/lib/Bio/Path/Find/App/Role/Archivist.pm
@@ -301,7 +301,7 @@ sub _collect_filenames {
 sub _rename_file {
   my ( $self, $old_filename ) = @_;
 
-  my $new_basename = $old_filename->basename;
+  my $new_basename = file($old_filename)->basename;
 
   # honour the "--rename" option
   $new_basename =~ s/\#/_/g if $self->rename;


### PR DESCRIPTION
In `Bio::Path::Find::App::Role::Archivist::_rename_file`, make sure we convert the filename (string) to an
object, otherwise the call to `Path::Class::File::basename` fails...