### PR TITLE
Add ability to return all lanes in a database

### DIFF
--- a/lib/Bio/Path/Find/Finder.pm
+++ b/lib/Bio/Path/Find/Finder.pm
@@ -281,8 +281,8 @@ sub find_lanes {
 sub _find_all_lanes {
   my ( $self, $ids, $type, $processed, $qc, $lane_attributes ) = @_;
 
-  return unless ( defined $ids and scalar @$ids == 1 );
-  return unless ( defined $type and $type eq 'database' );
+  return [] unless ( defined $ids and scalar @$ids == 1 );
+  return [] unless ( defined $type and $type eq 'database' );
 
   my $dbname = $ids->[0];
 
@@ -290,7 +290,7 @@ sub _find_all_lanes {
   my $database = $self->_db_manager->get_database($dbname);
   unless ( defined $database ) {
     say STDERR qq|No such database ("$dbname")|;
-    return;
+    return [];
   }
 
   # get all lanes... This step is a cheap operation, because DBIC doesn't do a

--- a/t/07_finder.t
+++ b/t/07_finder.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 13;
+use Test::More tests => 33;
 use Test::Exception;
 use Test::Output;
 use Path::Class;
@@ -38,32 +38,101 @@ my $config = {
   },
 };
 
-#---------------------------------------
-
-# check the behaviour of the lane_class attribute
+#-------------------------------------------------------------------------------
 
 my $f;
 lives_ok { $f = Bio::Path::Find::Finder->new( config => $config ) }
   'got a finder';
 
-# first, the default value
-isa_ok $f->lane_class, 'Bio::Path::Find::Lane';
+# get a lane row to play with
+my $database = $f->_db_manager->get_database('pathogen_prok_track');
+my $schema   = $database->schema;
+my $lanes_rs = $schema->resultset('LatestLane');
+my $lane_row = $lanes_rs->first;
 
-throws_ok { $f = Bio::Path::Find::Finder->new(  lane_class => 'my_class' ) }
+#---------------------------------------
+
+# check the "_create_lane" method
+
+my $lane;
+lives_ok { $f->_create_lane($lane_row) } 'no exception when creating a Lane';
+
+is $f->_create_lane($lane_row, 4096),        undef, 'no lane when filtered on "processed"';
+is $f->_create_lane($lane_row, undef, 'passed'), undef, 'no lane when filtered on QC';
+
+$lane = $f->_create_lane($lane_row, undef, 'pending', {search_depth => 2});
+ok $lane, 'got lane with no filtering';
+is $lane->search_depth, 2, 'attribute correctly set on lane';
+
+#---------------------------------------
+
+# check "_find_lanes"
+
+my $lanes;
+lives_ok { $lanes = $f->_find_lanes( [ '10263_4' ], 'lane' ) }
+  'no exception from "_find_lanes"';
+
+is scalar @$lanes, 87, 'got expected number of lanes from "_find_lanes"';
+
+$lanes = $f->_find_lanes( [ '10263_4' ], 'lane', undef );
+is scalar @$lanes, 87, '87 lanes from "_find_lanes" when "processed" is undef';
+$lanes = $f->_find_lanes( [ '10263_4' ], 'lane', 4096 );
+is scalar @$lanes, 0, 'no lanes from "_find_lanes" when filtered on "processed"';
+$lanes =$f->_find_lanes( [ '10263_4' ], 'lane', undef, 'passed' );
+is scalar @$lanes, 0, 'no lanes from "_find_lanes" when filtered on QC status';
+
+#---------------------------------------
+
+# check "_find_all_lanes"
+
+is $f->_find_all_lanes, undef, '"_find_all_lanes" returns undef without IDs';
+is $f->_find_all_lanes([]), undef, '"_find_all_lanes" returns undef with empty IDs array';
+is $f->_find_all_lanes( ['pathogen_prok_track']), undef, '"_find_all_lanes" returns undef without type';
+is $f->_find_all_lanes( ['pathogen_prok_track'], 'lane'), undef,
+  '"_find_all_lanes" returns undef with type ne "database';
+
+stderr_like { $f->_find_all_lanes(['no_such_db'], 'database') }
+  qr/^No such database \("no_such_db"\)/,
+  'got "no such database" from "_find_all_lanes"';
+
+throws_ok { $f->_find_all_lanes(['pathogen_prok_track'], 'database') }
+  qr/bad thing to do/,
+  'got exception from "_find_all_lanes" without env var set';
+
+$ENV{PF_ENABLE_DB_DUMP} = 1;
+lives_ok { $lanes= $f->_find_all_lanes(['pathogen_prok_track'], 'database') }
+  'no exception from "_find_all_lanes" with env var set';
+
+is scalar @$lanes, 236, 'got all lanes from "_find_all_lanes"';
+
+$lanes = $f->_find_all_lanes(['pathogen_prok_track'], 'database', undef );
+is scalar @$lanes, 236, '236 lanes from "_find_all_lanes" when "processed" is undef';
+$lanes = $f->_find_all_lanes(['pathogen_prok_track'], 'database', 4096 );
+is scalar @$lanes, 0, 'no lanes from "_find_all_lanes" when filtered on "processed"';
+$lanes = $f->_find_all_lanes(['pathogen_prok_track'], 'database', undef, 'passed' );
+is scalar @$lanes, 11, '11 lanes from "_find_all_lanes" when filtered on QC status';
+
+#---------------------------------------
+
+# check the behaviour of the lane_class attribute
+
+# first, the default value
+is $f->lane_class, 'Bio::Path::Find::Lane', 'lane class default is as expected';
+
+throws_ok { $f = Bio::Path::Find::Finder->new( lane_class => 'my_class' ) }
   qr/does not pass the type constraint/,
   'exception when trying to use non-existent lane class';
 
 # check that we can set the name of the role correctly using lane_class
-$f = Bio::Path::Find::Finder->new( lane_class => 'Bio::Path::Find::Lane::Class::Data' );
+lives_ok { $f = Bio::Path::Find::Finder->new( lane_class => 'Bio::Path::Find::Lane::Class::Data' ) }
+  'no exception using valid lane class name';
 
-my $lanes;
+# check "find_lanes"
 lives_ok { $lanes = $f->find_lanes( ids => [ '10263_4' ], type => 'lane' ) }
   'no exception getting lanes when valid lane_class specified';
 
 isa_ok $lanes->[0], 'Bio::Path::Find::Lane::Class::Data';
 ok $lanes->[0]->does('Bio::Path::Find::Lane::Role::Stats'), 'Stats Role applied to Lane';
-
-#---------------------------------------
 
 # make sure that we don't have any problems when we don't name a specific class
 $f = Bio::Path::Find::Finder->new;
@@ -75,25 +144,12 @@ isa_ok $lanes->[0], 'Bio::Path::Find::Lane';
 
 #---------------------------------------
 
-# make sure the finding works as expected
+lives_ok { $lanes = $f->find_lanes( ids => [ 'pathogen_prok_track' ], type => 'database' ) }
+  'no exception getting all lanes in database';
 
-is scalar @$lanes, 87, 'found 87 lanes with ID 10263_4';
+is scalar @$lanes, 236, 'got expected number of lanes with type "database"';
 
-# check we can filter by QC status
-$lanes = $f->find_lanes(
-  ids  => [ '10263_4' ],
-  type => 'lane',
-  qc   => 'failed',
-);
-
-is scalar @$lanes, 76, 'found 76 failed lanes with ID 10263_4';
-
-# look for lanes from a given study and check there's no progress bar
-stdout_is { $lanes = $f->find_lanes( ids  => [ 607 ], type => 'study' ) }
-  '',
-  'no progress bar shown';
-
-is scalar @$lanes, 50, 'found 50 lanes in study 607';
+#-------------------------------------------------------------------------------
 
 # done_testing;
 

--- a/t/07_finder.t
+++ b/t/07_finder.t
@@ -85,10 +85,10 @@ is scalar @$lanes, 0, 'no lanes from "_find_lanes" when filtered on QC status';
 
 # check "_find_all_lanes"
 
-is $f->_find_all_lanes, undef, '"_find_all_lanes" returns undef without IDs';
-is $f->_find_all_lanes([]), undef, '"_find_all_lanes" returns undef with empty IDs array';
-is $f->_find_all_lanes( ['pathogen_prok_track']), undef, '"_find_all_lanes" returns undef without type';
-is $f->_find_all_lanes( ['pathogen_prok_track'], 'lane'), undef,
+is_deeply $f->_find_all_lanes, [], '"_find_all_lanes" returns undef without IDs';
+is_deeply $f->_find_all_lanes([]), [], '"_find_all_lanes" returns undef with empty IDs array';
+is_deeply $f->_find_all_lanes( ['pathogen_prok_track']), [], '"_find_all_lanes" returns undef without type';
+is_deeply $f->_find_all_lanes( ['pathogen_prok_track'], 'lane'), [],
   '"_find_all_lanes" returns undef with type ne "database';
 
 stderr_like { $f->_find_all_lanes(['no_such_db'], 'database') }


### PR DESCRIPTION
Add a method to the Finder that can return all of the lanes in a particular database. Because that's a potentially dangerous operation, the user must set an environment variable to force it.