### PR TITLE
check number of results returned

### DIFF
--- a/lib/Bio/Path/Find/Finder.pm
+++ b/lib/Bio/Path/Find/Finder.pm
@@ -368,7 +368,7 @@ sub _find_lanes {
 
       my $rs = $database->schema->get_lanes_by_id($id, $type, $processed);
 
-      next ID unless $rs; # no matching lanes
+      next ID if( $rs->count == 0); # no matching lanes
 
       $self->log->debug('found ' . $rs->count . ' lanes');
 


### PR DESCRIPTION
results set always returns an object so empty rs were never caught. Change it to use count (which is called anyway).