### PR TITLE
fix mapfind warnings in RT60081

### DIFF
--- a/lib/Bio/Path/Find/Lane/Class/Map.pm
+++ b/lib/Bio/Path/Find/Lane/Class/Map.pm
@@ -101,7 +101,7 @@ sub _generate_filenames {
     $returned_file = $raw_file;
 
     carp qq(WARNING: expected to find raw bam file at "$returned_file", but it was missing)
-      unless -f file($self->storage_path, $raw_file);
+      unless -f file($self->symlink_path, $raw_file);
   }
   push  @returned_files, file( $self->symlink_path, $returned_file);
   

--- a/t/29_pf_map.t
+++ b/t/29_pf_map.t
@@ -110,6 +110,8 @@ $mf->clear_config;
 $mf = Bio::Path::Find::App::PathFind::Map->new(%params);
 my $expected_stdout = join '', <DATA>;
 
+# Stops map warnings for file path. Remove if testing details.
+local( $SIG{__WARN__} )= sub { my $warnings="# ",@_ };
 stdout_like { $mf->run } qr/$expected_stdout/, 'got expected details';
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
update storage path to symlink path to fix mapfind warnings in RT60081 and capture wanted warnings in test 29