### PR TITLE
Add summary to pf rnaseq

### DIFF
--- a/lib/Bio/Path/Find/App/PathFind/Info.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Info.pm
@@ -335,7 +335,6 @@ sub run {
   foreach my $lane ( @$lanes ) {
     my @lane_info = $self->_get_lane_info($lane);
     push @info, @lane_info;
-
     $pb++;
   }
 

--- a/lib/Bio/Path/Find/App/PathFind/RNASeq.pm
+++ b/lib/Bio/Path/Find/App/PathFind/RNASeq.pm
@@ -27,6 +27,7 @@ use Bio::Path::Find::Lane::Class::RNASeq;
 
 extends 'Bio::Path::Find::App::PathFind';
 
+
 with 'Bio::Path::Find::App::Role::Archivist',
      'Bio::Path::Find::App::Role::Linker',
      'Bio::Path::Find::App::Role::Statistician',

--- a/lib/Bio/Path/Find/App/PathFind/RNASeq.pm
+++ b/lib/Bio/Path/Find/App/PathFind/RNASeq.pm
@@ -30,6 +30,7 @@ extends 'Bio::Path::Find::App::PathFind';
 with 'Bio::Path::Find::App::Role::Archivist',
      'Bio::Path::Find::App::Role::Linker',
      'Bio::Path::Find::App::Role::Statistician',
+     'Bio::Path::Find::App::Role::RNASeqSummariser',
      'Bio::Path::Find::App::Role::UsesMappings';
 
 #-------------------------------------------------------------------------------
@@ -71,8 +72,11 @@ Use "pf man" or "pf man rnaseq" to see more information.
   # find coverage plots for lanes that were mapped using a specific mapper
   pf rnaseq -t lane -i 12345_1 -M smalt -f coverage
 
-  # get statisticss for lanes mapped against a specific reference
+  # get statistics for lanes mapped against a specific reference
   pf rnaseq -t lane -i 12345_1 -R Streptococcus_suis_P1_7_v1 -s
+
+  # get summary of lane metadata and corresponding count filenames
+  pf rnaseq -t lane -i 12345_1 -S
 
 =cut
 
@@ -114,6 +118,10 @@ reference.
 
 Write a file with statistics for the found lanes. Save to specified filename,
 if given.
+
+=item --summary, -S [<summary filename>]
+Write a file with metadata and file paths for the found lanes. If a filename 
+is given, the summary will be writen to that file.
 
 =item --symlink, -l [<symlink directory>]
 
@@ -233,6 +241,17 @@ name for a reference using C<pf ref>:
   Escherichia_coli_9000_v0.1
   ...
 
+=head2 Write a summary TSV file
+
+You can generate a single summary file which contains the lane metadata and the 
+corresponding expression pipeline filename using C<--summary> (abbreviated to C<-S>):
+
+pf rnaseq -t lane -i 12345_1 -S
+
+If the file type has been set, the corresponding file names will be used:
+
+pf rnaseq -t lane -i 12345_1 -f featurecounts -S
+
 =head2 Archive or link the found files
 
 You can generate a tar file or a zip file containing all of the files that are
@@ -350,6 +369,12 @@ sub run {
         msg => 'ERROR: stats file "' . $self->_stats_file . '" already exists; not overwriting. Use "-F" to force overwriting'
       );
     }
+
+    if ( $self->_summary_flag and -f $self->_summary_file and not $self->force ) {
+      Bio::Path::Find::Exception->throw(
+        msg => q(ERROR: TSV file ") . $self->_summary_file . q(" already exists; not overwriting existing file)
+      );
+    }
   }
 
   #---------------------------------------
@@ -403,12 +428,14 @@ sub run {
   if ( $self->_symlink_flag or
        $self->_tar_flag or
        $self->_zip_flag or
-       $self->_stats_flag ) {
+       $self->_stats_flag or
+       $self->_summary_flag ) {
     # can make symlinks, tarball or zip archive all in the same run
     $self->_make_symlinks($lanes) if $self->_symlink_flag;
     $self->_make_tar($lanes)      if $self->_tar_flag;
     $self->_make_zip($lanes)      if $self->_zip_flag;
     $self->_make_stats($lanes)    if $self->_stats_flag;
+    $self->_make_summary($lanes)  if $self->_summary_flag;
   }
   else {
     # print the list of files. Should we show extra info ?

--- a/lib/Bio/Path/Find/App/Role/RNASeqSummariser.pm
+++ b/lib/Bio/Path/Find/App/Role/RNASeqSummariser.pm
@@ -25,6 +25,8 @@ use Bio::Path::Find::Types qw(
   PathClassFile
 );
 
+use Data::Dumper;
+
 with 'Bio::Path::Find::Role::HasProgressBar';
 
 
@@ -78,20 +80,23 @@ sub _build_summary_file {
 sub _make_summary {
   my ( $self, $lanes ) = @_;
 
-  #collect the info for the supplied lanes
+  #Get summary headers
   my @summary = (
     $lanes->[0]->summary_headers,
   );
 
+  # Progress bar
   my $pb = $self->_create_pb('collecting summary', scalar @$lanes);
 
+  #Get lane summary
   foreach my $lane ( @$lanes ) {
     push @summary, $lane->summary;
     $pb++;
   }
 
-  $self->_csv->sep("\t");
-  $self->_write_csv(\@summary, $self->_summary_file);
+  # Write summary to file (tab-delimited)
+  $self->csv_separator("\t");
+  $self->_write_csv(\@summary, $self->_summary_file,);
 
   say q(Wrote summary to ") . $self->_summary_file . q(");
 }

--- a/lib/Bio/Path/Find/App/Role/RNASeqSummariser.pm
+++ b/lib/Bio/Path/Find/App/Role/RNASeqSummariser.pm
@@ -27,6 +27,7 @@ use Bio::Path::Find::Types qw(
 
 with 'Bio::Path::Find::Role::HasProgressBar';
 
+
 #-------------------------------------------------------------------------------
 #- private attributes ----------------------------------------------------------
 #-------------------------------------------------------------------------------
@@ -85,12 +86,12 @@ sub _make_summary {
   my $pb = $self->_create_pb('collecting summary', scalar @$lanes);
 
   foreach my $lane ( @$lanes ) {
-    $lane->filetype($self->filetype);
-    #push @summary, @{ $lane->summary };
+    push @summary, $lane->summary;
     $pb++;
   }
 
-  #$self->_write_csv(\@stats, $self->_stats_file);
+  $self->_csv->sep("\t");
+  $self->_write_csv(\@summary, $self->_summary_file);
 
   say q(Wrote summary to ") . $self->_summary_file . q(");
 }

--- a/lib/Bio/Path/Find/App/Role/RNASeqSummariser.pm
+++ b/lib/Bio/Path/Find/App/Role/RNASeqSummariser.pm
@@ -1,0 +1,100 @@
+
+package Bio::Path::Find::App::Role::RNASeqSummariser;
+
+# ABSTRACT: role providing methods for archiving data
+
+use v5.10; # for "say"
+
+use MooseX::App::Role;
+
+=head1 CONTACT
+a
+path-help@sanger.ac.uk
+
+=cut
+
+use Path::Class;
+
+use Bio::Path::Find::Exception;
+
+use Types::Standard qw(
+  +Bool
+);
+
+use Bio::Path::Find::Types qw(
+  PathClassFile
+);
+
+with 'Bio::Path::Find::Role::HasProgressBar';
+
+#-------------------------------------------------------------------------------
+#- private attributes ----------------------------------------------------------
+#-------------------------------------------------------------------------------
+
+option 'summary' => (
+  documentation => 'filename for summary TSV output',
+  is            => 'rw',
+  # no "isa" because we want to accept both Bool and Str
+  cmd_aliases   => 'S',
+  trigger       => \&_check_for_summary_value,
+);
+
+sub _check_for_summary_value {
+  my ( $self, $new, $old ) = @_;
+
+  if ( not defined $new ) {
+    $self->_summary_flag(1);
+  }
+  elsif ( not is_Bool($new) ) {
+    $self->_summary_flag(1);
+    $self->_summary_file( file $new );
+  }
+  else {
+    $self->_summary_flag(0);
+  }
+}
+
+has '_summary_flag' => ( is => 'rw', isa => Bool );
+
+has '_summary_file' => (
+  is      => 'rw',
+  isa     => PathClassFile,
+  lazy    => 1,
+  builder => '_build_summary_file',
+);
+
+sub _build_summary_file {
+  my $self = shift;
+  return file( $self->_renamed_id . '.rnaseqfind_summary.tsv' );
+}
+
+#-------------------------------------------------------------------------------
+#- private methods -------------------------------------------------------------
+#-------------------------------------------------------------------------------
+
+# build a CSV file with the statistics for all lanes and write it to file
+
+sub _make_summary {
+  my ( $self, $lanes ) = @_;
+
+  #collect the info for the supplied lanes
+  my @summary = (
+    $lanes->[0]->summary_headers,
+  );
+
+  my $pb = $self->_create_pb('collecting summary', scalar @$lanes);
+
+  foreach my $lane ( @$lanes ) {
+    $lane->filetype($self->filetype);
+    #push @summary, @{ $lane->summary };
+    $pb++;
+  }
+
+  #$self->_write_csv(\@stats, $self->_stats_file);
+
+  say q(Wrote summary to ") . $self->_summary_file . q(");
+}
+
+#-------------------------------------------------------------------------------
+
+1;

--- a/lib/Bio/Path/Find/Lane/Class/RNASeq.pm
+++ b/lib/Bio/Path/Find/Lane/Class/RNASeq.pm
@@ -18,6 +18,8 @@ use Types::Standard qw(
 
 use Bio::Path::Find::Types qw( :all );
 
+use Bio::Path::Find::App::PathFind::Info;
+
 extends 'Bio::Path::Find::Lane';
 
 with 'Bio::Path::Find::Lane::Role::HasMapping';
@@ -68,10 +70,19 @@ sub _build_skip_extension_fallback { 1 }
 # required by the RNASeqSummary Role
 
 sub _build_summary {
+  my $lane = shift;
+  my $file_path = shift;
 
-  use Data::Dumper;
-  print Dumper shift->_get_mapping_files('featurecounts');
+  my $lane_name = $lane->row->{'_column_data'}->{'name'}; 
+  my $if = Bio::Path::Find::App::PathFind::Info->new('id' => $lane_name, 'type' => 'lane');
+  my @lane_summary = $if->_get_lane_info($lane);
+  my $summary = $lane_summary[0];
 
+  my $file = file($lane->all_files); 
+  push @{$summary}, $file->basename;
+  push @{$summary}, $file->stringify;
+  
+  return $summary;
 }
 
 #-------------------------------------------------------------------------------

--- a/lib/Bio/Path/Find/Lane/Class/RNASeq.pm
+++ b/lib/Bio/Path/Find/Lane/Class/RNASeq.pm
@@ -8,6 +8,7 @@ use v5.10; # for "say"
 use Moose;
 use Path::Class;
 use Carp qw( carp );
+use Data::Dumper;
 
 use Types::Standard qw(
   Maybe
@@ -17,7 +18,6 @@ use Types::Standard qw(
 );
 
 use Bio::Path::Find::Types qw( :all );
-
 use Bio::Path::Find::App::PathFind::Info;
 
 extends 'Bio::Path::Find::Lane';
@@ -70,18 +70,21 @@ sub _build_skip_extension_fallback { 1 }
 # required by the RNASeqSummary Role
 
 sub _build_summary {
+
   my $lane = shift;
   my $file_path = shift;
-
+  
   my $lane_name = $lane->row->{'_column_data'}->{'name'}; 
   my $if = Bio::Path::Find::App::PathFind::Info->new('id' => $lane_name, 'type' => 'lane');
   my @lane_summary = $if->_get_lane_info($lane);
   my $summary = $lane_summary[0];
+  my $file = $lane->files->[0];
 
-  my $file = file($lane->all_files); 
-  push @{$summary}, $file->basename;
-  push @{$summary}, $file->stringify;
-  
+  if ($file) {
+    push @{$summary}, $file->basename;
+    push @{$summary}, $file->stringify;
+  }
+ 
   return $summary;
 }
 
@@ -96,11 +99,11 @@ sub _build_summary_headers {
 
   return [  'Lane',
             'Sample',
-            'Supplier Name',
-            'Public Name',
+            'Supplier_Name',
+            'Public_Name',
             'Strain',
             'Filename',
-            'File Path'
+            'File_Path'
         ];
 }
 

--- a/lib/Bio/Path/Find/Lane/Class/RNASeq.pm
+++ b/lib/Bio/Path/Find/Lane/Class/RNASeq.pm
@@ -21,6 +21,7 @@ use Bio::Path::Find::Types qw( :all );
 extends 'Bio::Path::Find::Lane';
 
 with 'Bio::Path::Find::Lane::Role::HasMapping';
+with 'Bio::Path::Find::Lane::Role::RNASeqSummary';
 	
 #-------------------------------------------------------------------------------
 #- public attributes -----------------------------------------------------------
@@ -58,6 +59,39 @@ sub _build_filetype_extensions {
 # filters
 
 sub _build_skip_extension_fallback { 1 }
+
+
+#-------------------------------------------------------------------------------
+
+# collect together the fields for the RNASeq summary display
+#
+# required by the RNASeqSummary Role
+
+sub _build_summary {
+
+  use Data::Dumper;
+  print Dumper shift->_get_mapping_files('featurecounts');
+
+}
+
+#-------------------------------------------------------------------------------
+
+# build an array of headers for the RNASeq summary display
+#
+# required by the RNASeqSummary Role
+
+sub _build_summary_headers {
+  my $self = shift;
+
+  return [  'Lane',
+            'Sample',
+            'Supplier Name',
+            'Public Name',
+            'Strain',
+            'Filename',
+            'File Path'
+        ];
+}
 
 #-------------------------------------------------------------------------------
 #- private methods -------------------------------------------------------------

--- a/lib/Bio/Path/Find/Lane/Role/RNASeqSummary.pm
+++ b/lib/Bio/Path/Find/Lane/Role/RNASeqSummary.pm
@@ -1,0 +1,64 @@
+
+package Bio::Path::Find::Lane::Role::RNASeqSummary;
+
+# ABSTRACT: a role that provides methods for retrieving and formatting RNASeq summary for lanes
+
+use Moose::Role;
+
+use Path::Class;
+
+use Types::Standard qw(
+  ArrayRef
+  HashRef
+  Str
+  Int
+  Bool
+  +Num
+);
+
+use Bio::Path::Find::Types qw(
+  BioTrackSchemaResultBase
+);
+
+requires '_build_summary_headers',
+         '_build_summary';
+
+#-------------------------------------------------------------------------------
+#- public attributes -----------------------------------------------------------
+#-------------------------------------------------------------------------------
+
+=attr headers
+
+Reference to an array containing column headers for summary output.
+
+=cut
+
+has 'summary_headers' => (
+  is      => 'ro',
+  isa     => ArrayRef[Str],
+  lazy    => 1,
+  builder => '_build_summary_headers',
+);
+
+#---------------------------------------
+
+=attr summary
+
+Reference to an array containing ssummary. Column order is the same as in
+L<headers>.
+
+=cut
+
+has 'summary' => (
+  is      => 'ro',
+  isa     => ArrayRef[ArrayRef],
+  lazy    => 1,
+  builder => '_build_summary',
+);
+
+
+#-------------------------------------------------------------------------------
+#- private attributes ----------------------------------------------------------
+#-------------------------------------------------------------------------------
+
+1;

--- a/lib/Bio/Path/Find/Lane/Role/RNASeqSummary.pm
+++ b/lib/Bio/Path/Find/Lane/Role/RNASeqSummary.pm
@@ -51,7 +51,7 @@ L<headers>.
 
 has 'summary' => (
   is      => 'ro',
-  isa     => ArrayRef[ArrayRef],
+#  isa     => ArrayRef[ArrayRef],
   lazy    => 1,
   builder => '_build_summary',
 );

--- a/t/06_lane/12_lane_class_rnaseqsummary.t
+++ b/t/06_lane/12_lane_class_rnaseqsummary.t
@@ -1,0 +1,99 @@
+# a dummy Role that provides the two required methods for the RNASeqSummary Role.
+
+package TestRole;
+
+use Moose::Role;
+
+with 'Bio::Path::Find::Lane::Role::RNASeqSummary';
+
+sub _build_summary_headers {
+  [ 'one', 'two' ];
+}
+
+sub _build_summary {
+  [ [ 1, 2, ] ];
+}
+
+#-------------------------------------------------------------------------------
+
+package main;
+
+use strict;
+use warnings;
+
+use Test::More tests => 6;
+use Test::Exception;
+use Test::Output;
+use Test::Warn;
+use Path::Class;
+use File::Temp qw( tempdir );
+use Cwd;
+
+# set up the "linked" directory for the test suite
+use lib 't';
+
+use Test::Setup;
+
+unless ( -d dir( qw( t data linked ) ) ) {
+  diag 'creating symlink directory';
+  Test::Setup::make_symlinks;
+}
+use_ok('Bio::Path::Find::DatabaseManager');
+
+use Bio::Path::Find::DatabaseManager;
+
+use Log::Log4perl qw( :easy );
+
+# initialise l4p to avoid warnings
+Log::Log4perl->easy_init( $FATAL );
+
+use_ok('Bio::Path::Find::Lane');
+
+#---------------------------------------
+
+# set up a DBM
+
+my $config = {
+  db_root           => dir(qw( t data linked )),
+  connection_params => {
+    tracking => {
+      driver       => 'SQLite',
+      dbname       => file(qw( t data pathogen_prok_track.db )),
+      schema_class => 'Bio::Track::Schema',
+    },
+  },
+};
+
+my $dbm = Bio::Path::Find::DatabaseManager->new(
+  config      => $config,
+  schema_name => 'tracking',
+);
+
+my $database  = $dbm->get_database('pathogen_prok_track');
+my $lane_rows = $database->schema->get_lanes_by_id(['10018_1#30'], 'lane');
+
+my $lane_row = $lane_rows->first;
+$lane_row->database($database);
+
+#---------------------------------------
+
+# get a Lane, with Role applied
+
+my $lane;
+
+lives_ok { $lane = Bio::Path::Find::Lane->with_traits('TestRole')
+                                        ->new( row => $lane_row ) }
+  'no exception when creating Lane with RNASeqSummary Role applied';
+
+ok $lane->does('Bio::Path::Find::Lane::Role::RNASeqSummary'), 'lane has RNASeqSummary Role applied';
+
+# make sure the overridden methods work
+my $expected_headers = [ qw( one two ) ];
+my $expected_summary   = [ [ 1, 2 ] ];
+
+is_deeply $lane->summary_headers, $expected_headers, 'got expected headers';
+is_deeply $lane->summary,         $expected_summary, 'got expected summary';
+
+#---------------------------------------
+
+# done_testing;

--- a/t/06_lane/12_lane_class_rnaseqsummary.t
+++ b/t/06_lane/12_lane_class_rnaseqsummary.t
@@ -75,6 +75,7 @@ my $lane_rows = $database->schema->get_lanes_by_id(['10018_1#30'], 'lane');
 my $lane_row = $lane_rows->first;
 $lane_row->database($database);
 
+
 #---------------------------------------
 
 # get a Lane, with Role applied
@@ -86,6 +87,7 @@ lives_ok { $lane = Bio::Path::Find::Lane->with_traits('TestRole')
   'no exception when creating Lane with RNASeqSummary Role applied';
 
 ok $lane->does('Bio::Path::Find::Lane::Role::RNASeqSummary'), 'lane has RNASeqSummary Role applied';
+
 
 # make sure the overridden methods work
 my $expected_headers = [ qw( one two ) ];

--- a/t/31_pf_rnaseq.t
+++ b/t/31_pf_rnaseq.t
@@ -44,7 +44,7 @@ use warnings;
 no warnings 'qw'; # don't warn about comments in lists when we put plux IDs
                   # inside qw( )
 
-use Test::More tests => 29;
+use Test::More tests => 31;
 use Test::Exception;
 use Test::Output;
 use Test::Warn;
@@ -287,6 +287,20 @@ combined_like { $sf->run }
   'got message about writing stats file';
 
 ok -f 'my_stats', 'found stats file';
+
+#---------------------------------------
+
+delete $params{stats};
+$params{summary} = 'my_summary';
+$params{force} = 1;
+
+$sf->clear_config;
+$sf = Bio::Path::Find::App::PathFind::RNASeq->new(%params);
+combined_like { $sf->run }
+  qr/Wrote summary to "my_summary"/,
+  'got message about writing summary file';
+
+ok -f 'my_summary', 'found summary file';
 
 #-------------------------------------------------------------------------------
 

--- a/t/31_pf_rnaseq.t
+++ b/t/31_pf_rnaseq.t
@@ -93,8 +93,6 @@ my %params = (
         no_db_root   => 1,
       },
     },
-    refs_index => file(qw( t data 31_pf_rnaseq refs.index ))->stringify,
-    refs_root  => file(qw( t data 31_pf_rnaseq            ))->stringify,
   },
   no_progress_bars   => 1,
   id                 => '10018_1#30',
@@ -245,6 +243,7 @@ $tf = Bio::Path::Find::App::TestFind->new(%params);
 stderr_is { $tf->run } 'called _make_summary', 'correctly called _make_summary';
 
 # multiple flags
+delete $params{summary};
 $params{archive} = 'my_tar';
 $params{stats}   = 'my_stats';
 $params{summary} = 'my_summary';

--- a/t/32_pf_rnaseq_summary.t
+++ b/t/32_pf_rnaseq_summary.t
@@ -1,0 +1,136 @@
+
+use strict;
+use warnings;
+
+use Test::More tests => 16;
+use Test::Exception;
+use Test::Output;
+use Test::Warn;
+use Path::Class;
+use File::Temp qw( tempdir );
+use Cwd;
+use Compress::Zlib;
+use Try::Tiny;
+use Text::CSV_XS qw( csv );
+use Capture::Tiny ':all';
+use Data::Dumper;
+
+# set up the "linked" directory for the test suite
+use lib 't';
+
+use Test::Setup;
+
+unless ( -d dir( qw( t data linked ) ) ) {
+  diag 'creating symlink directory';
+  Test::Setup::make_symlinks;
+}
+use_ok('Bio::Path::Find::DatabaseManager');
+
+use Bio::Path::Find::Finder;
+
+# initialise l4p to avoid warnings
+use Log::Log4perl qw( :easy );
+Log::Log4perl->easy_init( $FATAL );
+
+use_ok('Bio::Path::Find::App::PathFind::RNASeq');
+
+# set up a temp dir where we can write the archive
+my $temp_dir = File::Temp->newdir;
+dir( $temp_dir, 't' )->mkpath;
+my $orig_cwd = getcwd;
+symlink dir( $orig_cwd, qw( t data ) ), dir( $temp_dir, qw( t data ) )
+  or die "ERROR: couldn't link data directory into temp directory";
+chdir $temp_dir;
+
+my $expected_summary_file         = file(qw( t data 32_pf_rnaseq_summary expected_summary.tsv ));
+my @expected_summary              = $expected_summary_file->slurp( chomp => 1, split => qr|\t| );
+
+#-------------------------------------------------------------------------------
+
+# get some test lanes using the Finder directly
+my $f = Bio::Path::Find::Finder->new(
+  config     => file( qw( t data 32_pf_rnaseq_summary prod.conf ) ),
+  lane_class => 'Bio::Path::Find::Lane::Class::RNASeq',
+);
+
+my $lanes = $f->find_lanes( ids => [ '10018_1#30' ], type => 'lane' );
+
+is scalar @$lanes, 1, 'found 1 lane with ID 10018_1#30 using Finder';
+ok $lanes->[0]->does('Bio::Path::Find::Lane::Role::RNASeqSummary'), 'RNASeqSummary Role applied to Lanes';
+
+#-------------------------------------------------------------------------------
+
+# get a PathFind object
+
+my %params = (
+  # no need to pass "config_file"; it will come from the HasConfig Role
+  id               => '10018_1#30',
+  type             => 'lane',
+  no_progress_bars => 1,
+);
+
+my $pf;
+lives_ok { $pf = Bio::Path::Find::App::PathFind::RNASeq->new(%params) }
+  'got a new pathfind data command object';
+
+# write to automatically generated filename
+my $output;
+lives_ok { $output = capture_merged { $pf->_make_summary($lanes) } }
+  'no exception when calling _make_summary';
+
+my $summary_file = file( $temp_dir, '10018_1_30.rnaseqfind_summary.tsv' );
+ok -e $summary_file, 'summary named as expected';
+
+my $summary = csv( in => $summary_file->stringify, sep=>"\t", quote_char  => undef );
+is_deeply $summary, \@expected_summary, 'written contents look right';
+
+# write to specified filename
+$summary_file = file( $temp_dir, 'named_file.tsv' );
+
+%params = (
+  # no need to pass "config_file"; it will come from the HasConfig Role
+  id               => '10018_1#30',
+  type             => 'lane',
+  summary          => $summary_file->stringify,
+  no_progress_bars => 1,
+);
+
+$pf = Bio::Path::Find::App::PathFind::RNASeq->new(%params);
+
+lives_ok { $output = capture_merged { $pf->_make_summary($lanes) } }
+  'no exception when calling _make_summary';
+
+like $output, qr/Wrote summary to .*?named_file\.tsv/,
+  'got message with filename';
+
+ok -e $summary_file, 'summary named as expected';
+
+$summary = csv( in => $summary_file->stringify, sep=>"\t", quote_char  => undef  );
+# NOTE again, ignore the broken row
+
+$summary->[1] = $expected_summary[1];
+is_deeply $summary, \@expected_summary, 'contents of named file look right';
+
+# should get an error when writing to the same file a second time
+throws_ok { $output = capture_merged { $pf->_make_summary($lanes) } }
+  qr/already exists/,
+  'exception when calling _make_summary with existing file';
+
+like $output, qr/Wrote summary to .*?named_file\.tsv/,
+  'got message with filename';
+
+$params{force} = 1;
+$pf = Bio::Path::Find::App::PathFind::RNASeq->new(%params);
+
+lives_ok { $output = capture_merged { $pf->_make_summary($lanes) } }
+  'no exception when calling _make_summary with existing file but "force" is set to true';
+
+like $output, qr/Wrote summary to .*?named_file\.tsv/,
+  'got message with filename';
+
+#-------------------------------------------------------------------------------
+
+# done_testing;
+
+chdir $orig_cwd;
+

--- a/t/data/32_pf_rnaseq_summary/expected_summary.tsv
+++ b/t/data/32_pf_rnaseq_summary/expected_summary.tsv
@@ -1,0 +1,2 @@
+Lane	Sample	Supplier_Name	Public_Name	Strain	Filename	File_Path
+10018_1#30	APP_N1_OP2	NA	APP_N1_OP2	NA

--- a/t/data/32_pf_rnaseq_summary/prod.conf
+++ b/t/data/32_pf_rnaseq_summary/prod.conf
@@ -1,0 +1,19 @@
+
+log_file pathfind.log
+
+db_root t/data/linked
+
+<connection_params>
+  <tracking>
+    driver       SQLite
+    dbname       t/data/pathogen_prok_track.db
+    schema_class Bio::Track::Schema
+  </tracking>
+  <sequencescape>
+    driver       SQLite
+    dbname       t/data/sequencescape_warehouse.db
+    schema_class Bio::Sequencescape::Schema
+    no_db_root   1
+  </sequencescape>
+</connection_params>
+

--- a/t/data/32_pf_rnaseq_summary/true_expected_summary.tsv
+++ b/t/data/32_pf_rnaseq_summary/true_expected_summary.tsv
@@ -1,0 +1,2 @@
+Lane	Sample	Supplier_Name	Public_Name	Strain	Filename	File_Path
+10018_1#30	APP_N1_OP2	NA	APP_N1_OP2	NA	544507.se.raw.sorted.bam.expression.csv	t/data/linked/prokaryotes/seq-pipelines/Actinobacillus/pleuropneumoniae/TRACKING/607/APP_N1_OP2/SLX/APP_N1_OP2_7492554/10018_1#30/544507.se.raw.sorted.bam.expression.csv


### PR DESCRIPTION
Add `--summary `(-S) to `pf rnaseq`
Produces merge of `pf info` and `pf rnaseq`

    Lane	Sample	Supplier_Name	Public_Name	Strain	Filename	File_Path
    10018_1#30	APP_N1_OP2	NA	APP_N1_OP2	NA	544507.se.raw.sorted.bam.expression.csv	t/data/linked/prokaryotes/seq-pipelines/Actinobacillus/pleuropneumoniae/TRACKING/607/APP_N1_OP2/SLX/APP_N1_OP2_7492554/10018_1#30/544507.se.raw.sorted.bam.expression.csv

_Note: database missing CSV file paths so test output excludes the filepath_