### PR TITLE
replace spaces with underscores in stats filenames

### DIFF
--- a/lib/Bio/Path/Find/App/PathFind.pm
+++ b/lib/Bio/Path/Find/App/PathFind.pm
@@ -324,7 +324,7 @@ option 'id' => (
   required      => 1,
   trigger       => sub {
     my ( $self, $id ) = @_;
-    ( my $renamed_id = $id ) =~ s/\#/_/g;
+    ( my $renamed_id = $id ) =~ s/\#|\s|\//_/g;
     $self->_renamed_id( $renamed_id );
   },
 );

--- a/lib/Bio/Path/Find/App/PathFind/Accession.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Accession.pm
@@ -472,6 +472,7 @@ sub _generate_url {
   #
   # so we split on newline and use the second row in the map below
   my @content = split m/\n/, $res->decoded_content;
+  $content[1] =~ s/\#/\%23/;
 
   # if we ask for URLs for fastq files, we could get a semi-colon delimited
   # list of URLs. Split the response string on ";" and tack on "ftp://" to

--- a/lib/Bio/Path/Find/App/PathFind/Status.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Status.pm
@@ -35,7 +35,7 @@ pf status - Find the status of samples
 
 =head1 USAGE
 
-  pf info --id <id> --type <ID type> [options]
+  pf status --id <id> --type <ID type> [options]
 
 =head1 DESCRIPTION
 

--- a/lib/Bio/Path/Find/Lane/Class/Assembly.pm
+++ b/lib/Bio/Path/Find/Lane/Class/Assembly.pm
@@ -48,7 +48,7 @@ has '+filetype' => (
 sub _build_filetype_extensions {
   return {
     contigs  => 'unscaffolded_contigs.fa',
-    scaffold => 'contigs.ga',
+    scaffold => 'contigs.fa',
     all      => '*contigs.fa',
   };
 }

--- a/t/19_pf_acc.t
+++ b/t/19_pf_acc.t
@@ -122,7 +122,7 @@ ftp.ebi.ac.uk/vol1/fastq/ERR028/ERR028809/ERR028809_1.fastq.gz;ftp.sra.ebi.ac.uk
 );
 $ua->map_response(
   qr(submitted_ftp) => HTTP::Response->new( 200, 'OK', undef, 'submitted_ftp
-ftp.ebi.ac.uk/vol1/ERA020/ERA020634/srf/5477_6#1.srf'),
+ftp.ebi.ac.uk/vol1/ERA020/ERA020634/srf/5477_6%231.srf'),
 );
 
 $params{_ua}   = $ua;           # pass in the fake UA
@@ -168,7 +168,7 @@ stderr_like { $af->run } qr/Wrote ENA URLs for submitted files to "s.txt"/, 'wri
 
 # check file contents
 $expected_urls = <<'EOF_urls';
-ftp://ftp.ebi.ac.uk/vol1/ERA020/ERA020634/srf/5477_6#1.srf
+ftp://ftp.ebi.ac.uk/vol1/ERA020/ERA020634/srf/5477_6%231.srf
 EOF_urls
 
 $got_urls = file('s.txt')->slurp;


### PR DESCRIPTION
Bugfix RT635214

pf assembly -t study -i study -s
If there are spaces in the study name it adds spaces to the stats filename - replace with underscore.