### PR TITLE
Add --prefix-with-library-name to pf data

### DIFF
--- a/lib/Bio/Path/Find/App/PathFind/Data.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Data.pm
@@ -13,6 +13,9 @@ use Path::Class;
 use Cwd;
 
 use Bio::Path::Find::Types qw( :types );
+use Types::Standard qw(
+  +Bool
+);
 
 use Bio::Path::Find::Exception;
 use Bio::Path::Find::Lane::Class::Data;
@@ -243,11 +246,12 @@ option 'qc' => (
   cmd_aliases   => 'q',
 );
 
-option 'prefix_with_library_name' => ( 
+option 'prefix_with_library_name' => (
   documentation => 'prefix symlinked files with library name',
   is            => 'ro',
-  isa           => 'Bool',
+  isa           => Bool,
   cmd_aliases   => 'p',
+  cmd_flag      => 'prefix-with-library-name',
 );
 
 #-------------------------------------------------------------------------------

--- a/lib/Bio/Path/Find/App/PathFind/Data.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Data.pm
@@ -116,6 +116,10 @@ filename, if given.
 Rename filenames when creating archives or symlinks, replacing hashed (#)
 with underscores (_).
 
+=item --prefix_with_library_name, -p
+
+Prefix symlinked files with the library name.
+
 =back
 
 =head1 SCENARIOS
@@ -206,6 +210,9 @@ necessary permissions for creating files or links in the working directory.
 As when creating archives, you can rename filenames when creating symlinks
 using C<--rename> to convert hashes to underscores.
 
+Symlinked files can also be prefixed with their corresponding library name 
+using C<--prefix_with_library_name>.
+
 =head1 SEE ALSO
 
 =over
@@ -234,6 +241,13 @@ option 'qc' => (
   is            => 'ro',
   isa           => QCState,
   cmd_aliases   => 'q',
+);
+
+option 'prefix_with_library_name' => ( 
+  documentation => 'prefix symlinked files with library name',
+  is            => 'ro',
+  isa           => 'Bool',
+  cmd_aliases   => 'p',
 );
 
 #-------------------------------------------------------------------------------

--- a/lib/Bio/Path/Find/App/PathFind/Supplementary.pm
+++ b/lib/Bio/Path/Find/App/PathFind/Supplementary.pm
@@ -19,8 +19,6 @@ use Types::Standard qw(
   +Bool
 );
 
-use Data::Dumper;
-
 use Bio::Path::Find::Types qw( :types );
 use Bio::Path::Find::App::PathFind::Accession;
 

--- a/lib/Bio/Path/Find/App/Role/Linker.pm
+++ b/lib/Bio/Path/Find/App/Role/Linker.pm
@@ -15,7 +15,6 @@ path-help@sanger.ac.uk
 
 use Path::Class;
 use Try::Tiny;
-
 use Bio::Path::Find::Exception;
 
 use Types::Standard qw(
@@ -115,12 +114,13 @@ sub _make_symlinks {
   my $pb = $self->_create_pb('linking', scalar @$lanes);
 
   my @links = ();
+
   foreach my $lane ( @$lanes ) {
     # the call to "make_symlinks" returns a reference to an array containing a
     # list of the entities (files or directories) for which the Lane has
     # successfully created links. We need to collect those and list them later,
     # when we're not in the middle of showing a progress bar
-    push @links, $lane->make_symlinks( dest => $dest, rename => $self->rename );
+    push @links, $lane->make_symlinks( dest => $dest, rename => $self->rename, prefix => $self->prefix_with_library_name );
     $pb++;
   }
 

--- a/lib/Bio/Path/Find/App/Role/RNASeqSummariser.pm
+++ b/lib/Bio/Path/Find/App/Role/RNASeqSummariser.pm
@@ -25,8 +25,6 @@ use Bio::Path::Find::Types qw(
   PathClassFile
 );
 
-use Data::Dumper;
-
 with 'Bio::Path::Find::Role::HasProgressBar';
 
 


### PR DESCRIPTION
No 1. in RT635223
Implemented for pacbio data

If using option with pf data and symlink without filetype, it prefixes the directory that is being symlinked with the library name

If using the filetype option, it prefixes the files which are being symlinked with the library name