### PR TITLE
add fix for RT642286 and update tests

### DIFF
--- a/lib/Bio/Path/Find/App/Role/Linker.pm
+++ b/lib/Bio/Path/Find/App/Role/Linker.pm
@@ -120,7 +120,11 @@ sub _make_symlinks {
     # list of the entities (files or directories) for which the Lane has
     # successfully created links. We need to collect those and list them later,
     # when we're not in the middle of showing a progress bar
-    push @links, $lane->make_symlinks( dest => $dest, rename => $self->rename, prefix => $self->prefix_with_library_name );
+    if ( my $ref = eval { $self->can( 'prefix_with_library_name'  ) } ) {
+		push @links, $lane->make_symlinks( dest => $dest, rename => $self->rename, prefix => $self->prefix_with_library_name );
+	} else {
+		push @links, $lane->make_symlinks( dest => $dest, rename => $self->rename);
+	}
     $pb++;
   }
 

--- a/t/13_pf_data_symlinking.t
+++ b/t/13_pf_data_symlinking.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 16;
+use Test::More tests => 18;
 use Test::Exception;
 use Test::Output;
 use Path::Class;
@@ -111,6 +111,16 @@ $pf = Bio::Path::Find::App::PathFind::Data->new(%params);
 throws_ok { $pf->_make_symlinks($lanes) }
   qr/couldn't make link directory/,
   'exception when destination exists as a file';
+
+# link to '.' with a progress bar
+$params{symlink} = '.';
+$pf = Bio::Path::Find::App::PathFind::Data->new(%params);
+$lanes = $f->find_lanes( ids => [ '10018_1#1' ], type => 'lane');
+combined_like { $pf->_make_symlinks($lanes) }
+  qr|Creating links in '.'|s, 
+  'creating links in correct directory (.)';
+$dest = dir( $temp_dir, '10018_1#1' );
+ok -l $dest, "found link directory '.'";
 
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
Update linker to check whether method prefix_with_library_name exists for command (should only exist for pf data)

Tests were giving false positive (RT 642286) - added to test 13 (data symlinking) to check if `-l .` works. 